### PR TITLE
Split IClassProvider

### DIFF
--- a/src/main/java/com/chaosbuffalo/mkultra/client/gui/PlayerClassScreen.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/client/gui/PlayerClassScreen.java
@@ -3,7 +3,6 @@ package com.chaosbuffalo.mkultra.client.gui;
 import com.chaosbuffalo.mkultra.GameConstants;
 import com.chaosbuffalo.mkultra.MKUltra;
 import com.chaosbuffalo.mkultra.core.*;
-import com.chaosbuffalo.mkultra.item.interfaces.IClassProvider;
 import com.chaosbuffalo.mkultra.network.packets.LevelAbilityPacket;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiButton;
@@ -56,7 +55,7 @@ public class PlayerClassScreen extends GuiScreen {
         //draw icons
         GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
         IClassClientData classProvider = playerClass.getClientData();
-        ResourceLocation iconLoc1 = classProvider.getIconForProvider();
+        ResourceLocation iconLoc1 = classProvider.getIcon();
         this.mc.renderEngine.bindTexture(iconLoc1);
         Gui.drawModalRectWithCustomSizedTexture(xPos + 6, iconHeight, 0, 0, 16, 16, 16, 16);
         for (int i = 0; i < GameConstants.ACTION_BAR_SIZE; i++) {

--- a/src/main/java/com/chaosbuffalo/mkultra/client/gui/PlayerClassScreen.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/client/gui/PlayerClassScreen.java
@@ -55,7 +55,7 @@ public class PlayerClassScreen extends GuiScreen {
         //drawing ability
         //draw icons
         GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
-        IClassProvider classProvider = playerClass.getClassProvider();
+        IClassClientData classProvider = playerClass.getClientData();
         ResourceLocation iconLoc1 = classProvider.getIconForProvider();
         this.mc.renderEngine.bindTexture(iconLoc1);
         Gui.drawModalRectWithCustomSizedTexture(xPos + 6, iconHeight, 0, 0, 16, 16, 16, 16);

--- a/src/main/java/com/chaosbuffalo/mkultra/client/gui/XpTableScreen.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/client/gui/XpTableScreen.java
@@ -35,7 +35,7 @@ public class XpTableScreen extends GuiScreen {
         int panelHeight = 165;
         int xPos = width / 2 - panelWidth / 2;
         int yPos = height / 2 - panelHeight / 2;
-        IClassProvider classProvider = (IClassProvider) playerClass.getClassProvider();
+        IClassClientData classProvider = playerClass.getClientData();
         ResourceLocation loc = classProvider.getXpTableBackground();
         GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
         this.mc.renderEngine.bindTexture(loc);

--- a/src/main/java/com/chaosbuffalo/mkultra/core/ClassClientData.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/ClassClientData.java
@@ -1,0 +1,79 @@
+package com.chaosbuffalo.mkultra.core;
+
+import com.chaosbuffalo.mkultra.MKUltra;
+import net.minecraft.util.ResourceLocation;
+
+public class ClassClientData {
+
+    public static class SunIcon implements IClassClientData {
+        public static SunIcon INSTANCE = new SunIcon();
+
+        @Override
+        public ResourceLocation getIconForProvider() {
+            return new ResourceLocation(MKUltra.MODID, "textures/class/icons/sun.png");
+        }
+
+        @Override
+        public String getXpTableText() {
+            return "Give your Brouzoufs to Solarius. Receive his blessings.";
+        }
+
+        @Override
+        public ResourceLocation getXpTableBackground() {
+            return new ResourceLocation(MKUltra.MODID, "textures/gui/xp_table_background.png");
+        }
+
+        @Override
+        public int getXpTableTextColor() {
+            return 38600;
+        }
+    }
+
+    public static class MoonIcon implements IClassClientData {
+        public static MoonIcon INSTANCE = new MoonIcon();
+
+        @Override
+        public ResourceLocation getIconForProvider() {
+            return new ResourceLocation(MKUltra.MODID, "textures/class/icons/moon.png");
+        }
+
+        @Override
+        public String getXpTableText() {
+            return "Thalassa, Goddess of the Moon, demands brouzouf in exchange for her powers.";
+        }
+
+        @Override
+        public ResourceLocation getXpTableBackground() {
+            return new ResourceLocation(MKUltra.MODID, "textures/gui/xp_table_background_moon.png");
+        }
+
+        @Override
+        public int getXpTableTextColor() {
+            return 4404838;
+        }
+    }
+
+    public static class DesperateIcon implements IClassClientData {
+        public static DesperateIcon INSTANCE = new DesperateIcon();
+
+        @Override
+        public ResourceLocation getIconForProvider() {
+            return new ResourceLocation(MKUltra.MODID, "textures/class/icons/desperate.png");
+        }
+
+        @Override
+        public String getXpTableText() {
+            return "Ydira, Elusive Spirit of the Wood, will increase your powers in exchange for brouzouf.";
+        }
+
+        @Override
+        public ResourceLocation getXpTableBackground() {
+            return new ResourceLocation(MKUltra.MODID, "textures/gui/xp_table_background_desperate.png");
+        }
+
+        @Override
+        public int getXpTableTextColor() {
+            return 32025;
+        }
+    }
+}

--- a/src/main/java/com/chaosbuffalo/mkultra/core/ClassClientData.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/ClassClientData.java
@@ -9,7 +9,7 @@ public class ClassClientData {
         public static SunIcon INSTANCE = new SunIcon();
 
         @Override
-        public ResourceLocation getIconForProvider() {
+        public ResourceLocation getIcon() {
             return new ResourceLocation(MKUltra.MODID, "textures/class/icons/sun.png");
         }
 
@@ -33,7 +33,7 @@ public class ClassClientData {
         public static MoonIcon INSTANCE = new MoonIcon();
 
         @Override
-        public ResourceLocation getIconForProvider() {
+        public ResourceLocation getIcon() {
             return new ResourceLocation(MKUltra.MODID, "textures/class/icons/moon.png");
         }
 
@@ -57,7 +57,7 @@ public class ClassClientData {
         public static DesperateIcon INSTANCE = new DesperateIcon();
 
         @Override
-        public ResourceLocation getIconForProvider() {
+        public ResourceLocation getIcon() {
             return new ResourceLocation(MKUltra.MODID, "textures/class/icons/desperate.png");
         }
 

--- a/src/main/java/com/chaosbuffalo/mkultra/core/IClassClientData.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/IClassClientData.java
@@ -3,7 +3,7 @@ package com.chaosbuffalo.mkultra.core;
 import net.minecraft.util.ResourceLocation;
 
 public interface IClassClientData {
-    ResourceLocation getIconForProvider();
+    ResourceLocation getIcon();
     String getXpTableText();
     ResourceLocation getXpTableBackground();
     int getXpTableTextColor();

--- a/src/main/java/com/chaosbuffalo/mkultra/core/IClassClientData.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/IClassClientData.java
@@ -1,0 +1,10 @@
+package com.chaosbuffalo.mkultra.core;
+
+import net.minecraft.util.ResourceLocation;
+
+public interface IClassClientData {
+    ResourceLocation getIconForProvider();
+    String getXpTableText();
+    ResourceLocation getXpTableBackground();
+    int getXpTableTextColor();
+}

--- a/src/main/java/com/chaosbuffalo/mkultra/core/MKURegistry.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/MKURegistry.java
@@ -93,8 +93,7 @@ public class MKURegistry {
 
     public static List<ResourceLocation> getClassesForProvider(IClassProvider provider) {
         return REGISTRY_CLASSES.getEntries().stream()
-                .filter(kv -> kv.getValue().getClassProvider()
-                        .getIconForProvider().equals(provider.getIconForProvider()))
+                .filter(kv -> provider.teachesClass(kv.getValue()))
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/chaosbuffalo/mkultra/core/PlayerClass.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/PlayerClass.java
@@ -45,6 +45,10 @@ public abstract class PlayerClass extends IForgeRegistryEntry.Impl<PlayerClass> 
 
     public abstract IClassProvider getClassProvider();
 
+    public IClassClientData getClientData() {
+        return getClassProvider();
+    }
+
     public abstract ArmorClass getArmorClass();
 
     public PlayerAbility getOfferedAbilityBySlot(int slotIndex) {

--- a/src/main/java/com/chaosbuffalo/mkultra/core/PlayerClass.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/PlayerClass.java
@@ -45,9 +45,7 @@ public abstract class PlayerClass extends IForgeRegistryEntry.Impl<PlayerClass> 
 
     public abstract IClassProvider getClassProvider();
 
-    public IClassClientData getClientData() {
-        return getClassProvider();
-    }
+    public abstract IClassClientData getClientData();
 
     public abstract ArmorClass getArmorClass();
 

--- a/src/main/java/com/chaosbuffalo/mkultra/core/PlayerData.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/PlayerData.java
@@ -823,7 +823,10 @@ public class PlayerData implements IPlayerData {
             return false;
 
         Item mainHand = mainHandStack.getItem();
-        return mainHand == baseClass.getClassProvider();
+        if (mainHand instanceof IClassProvider) {
+            return ((IClassProvider)mainHand).teachesClass(baseClass);
+        }
+        return false;
     }
 
     private boolean checkClassLearnEntity(BlockPos pos, ResourceLocation classId){
@@ -837,7 +840,7 @@ public class PlayerData implements IPlayerData {
         }
         if (tileEntity instanceof IClassProvider){
             IClassProvider provider = (IClassProvider) tileEntity;
-            return provider.getIconForProvider().equals(baseClass.getClassProvider().getIconForProvider());
+            return provider.teachesClass(baseClass);
         } else {
             return false;
         }

--- a/src/main/java/com/chaosbuffalo/mkultra/core/classes/Archer.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/classes/Archer.java
@@ -1,20 +1,20 @@
 package com.chaosbuffalo.mkultra.core.classes;
 
 import com.chaosbuffalo.mkultra.MKUltra;
-import com.chaosbuffalo.mkultra.core.PlayerAbility;
-import com.chaosbuffalo.mkultra.core.PlayerClass;
+import com.chaosbuffalo.mkultra.core.*;
 import com.chaosbuffalo.mkultra.core.abilities.*;
-import com.chaosbuffalo.mkultra.core.ArmorClass;
 import com.chaosbuffalo.mkultra.init.ModItems;
 import com.chaosbuffalo.mkultra.item.ClassIcon;
 import com.chaosbuffalo.mkultra.item.interfaces.IClassProvider;
 import net.minecraft.item.Item;
+import net.minecraft.util.ResourceLocation;
 
 import java.util.ArrayList;
 import java.util.List;
 
 
 public class Archer extends PlayerClass {
+    public static ResourceLocation ID = new ResourceLocation(MKUltra.MODID, "class.archer");
 
     public static final List<PlayerAbility> abilities = new ArrayList<>(5);
 
@@ -27,7 +27,7 @@ public class Archer extends PlayerClass {
     }
 
     public Archer() {
-        super(MKUltra.MODID, "class.archer");
+        super(ID);
     }
 
     @Override
@@ -73,5 +73,10 @@ public class Archer extends PlayerClass {
     @Override
     public IClassProvider getClassProvider() {
         return (ClassIcon) ModItems.sun_icon;
+    }
+
+    @Override
+    public IClassClientData getClientData() {
+        return ClassClientData.SunIcon.INSTANCE;
     }
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/core/classes/Brawler.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/classes/Brawler.java
@@ -1,10 +1,8 @@
 package com.chaosbuffalo.mkultra.core.classes;
 
 import com.chaosbuffalo.mkultra.MKUltra;
-import com.chaosbuffalo.mkultra.core.PlayerAbility;
-import com.chaosbuffalo.mkultra.core.PlayerClass;
+import com.chaosbuffalo.mkultra.core.*;
 import com.chaosbuffalo.mkultra.core.abilities.*;
-import com.chaosbuffalo.mkultra.core.ArmorClass;
 import com.chaosbuffalo.mkultra.init.ModItems;
 import com.chaosbuffalo.mkultra.item.ClassIcon;
 import com.chaosbuffalo.mkultra.item.interfaces.IClassProvider;
@@ -72,5 +70,10 @@ public class Brawler extends PlayerClass {
     @Override
     public IClassProvider getClassProvider() {
         return (ClassIcon) ModItems.sun_icon;
+    }
+
+    @Override
+    public IClassClientData getClientData() {
+        return ClassClientData.SunIcon.INSTANCE;
     }
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/core/classes/Cleric.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/classes/Cleric.java
@@ -1,9 +1,7 @@
 package com.chaosbuffalo.mkultra.core.classes;
 
 import com.chaosbuffalo.mkultra.MKUltra;
-import com.chaosbuffalo.mkultra.core.ArmorClass;
-import com.chaosbuffalo.mkultra.core.PlayerAbility;
-import com.chaosbuffalo.mkultra.core.PlayerClass;
+import com.chaosbuffalo.mkultra.core.*;
 import com.chaosbuffalo.mkultra.core.abilities.*;
 import com.chaosbuffalo.mkultra.init.ModItems;
 import com.chaosbuffalo.mkultra.item.ClassIcon;
@@ -72,5 +70,10 @@ public class Cleric extends PlayerClass {
     @Override
     public IClassProvider getClassProvider() {
         return (ClassIcon) ModItems.sun_icon;
+    }
+
+    @Override
+    public IClassClientData getClientData() {
+        return ClassClientData.SunIcon.INSTANCE;
     }
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/core/classes/Digger.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/classes/Digger.java
@@ -1,10 +1,8 @@
 package com.chaosbuffalo.mkultra.core.classes;
 
 import com.chaosbuffalo.mkultra.MKUltra;
-import com.chaosbuffalo.mkultra.core.PlayerAbility;
-import com.chaosbuffalo.mkultra.core.PlayerClass;
+import com.chaosbuffalo.mkultra.core.*;
 import com.chaosbuffalo.mkultra.core.abilities.*;
-import com.chaosbuffalo.mkultra.core.ArmorClass;
 import com.chaosbuffalo.mkultra.init.ModItems;
 import com.chaosbuffalo.mkultra.item.ClassIcon;
 import com.chaosbuffalo.mkultra.item.interfaces.IClassProvider;
@@ -76,6 +74,11 @@ public class Digger extends PlayerClass {
     @Override
     public IClassProvider getClassProvider() {
         return (ClassIcon) ModItems.sun_icon;
+    }
+
+    @Override
+    public IClassClientData getClientData() {
+        return ClassClientData.SunIcon.INSTANCE;
     }
 
     private static class DiggerArmorClass extends ArmorClass {

--- a/src/main/java/com/chaosbuffalo/mkultra/core/classes/Druid.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/classes/Druid.java
@@ -1,10 +1,8 @@
 package com.chaosbuffalo.mkultra.core.classes;
 
 import com.chaosbuffalo.mkultra.MKUltra;
-import com.chaosbuffalo.mkultra.core.PlayerAbility;
-import com.chaosbuffalo.mkultra.core.PlayerClass;
+import com.chaosbuffalo.mkultra.core.*;
 import com.chaosbuffalo.mkultra.core.abilities.*;
-import com.chaosbuffalo.mkultra.core.ArmorClass;
 import com.chaosbuffalo.mkultra.init.ModItems;
 import com.chaosbuffalo.mkultra.item.ClassIcon;
 import com.chaosbuffalo.mkultra.item.interfaces.IClassProvider;
@@ -72,5 +70,10 @@ public class Druid extends PlayerClass {
     @Override
     public IClassProvider getClassProvider() {
         return (ClassIcon) ModItems.sun_icon;
+    }
+
+    @Override
+    public IClassClientData getClientData() {
+        return ClassClientData.SunIcon.INSTANCE;
     }
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/core/classes/GreenKnight.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/classes/GreenKnight.java
@@ -1,14 +1,11 @@
 package com.chaosbuffalo.mkultra.core.classes;
 
 import com.chaosbuffalo.mkultra.MKUltra;
-import com.chaosbuffalo.mkultra.core.ArmorClass;
-import com.chaosbuffalo.mkultra.core.PlayerAbility;
-import com.chaosbuffalo.mkultra.core.PlayerClass;
+import com.chaosbuffalo.mkultra.core.*;
 import com.chaosbuffalo.mkultra.core.abilities.*;
 import com.chaosbuffalo.mkultra.init.ModItems;
 import com.chaosbuffalo.mkultra.item.ClassIcon;
 import com.chaosbuffalo.mkultra.item.interfaces.IClassProvider;
-import net.minecraft.item.Item;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -77,4 +74,8 @@ public class GreenKnight extends PlayerClass {
         return (ClassIcon) ModItems.desperate_icon;
     }
 
+    @Override
+    public IClassClientData getClientData() {
+        return ClassClientData.DesperateIcon.INSTANCE;
+    }
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/core/classes/MoonKnight.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/classes/MoonKnight.java
@@ -1,9 +1,7 @@
 package com.chaosbuffalo.mkultra.core.classes;
 
 import com.chaosbuffalo.mkultra.MKUltra;
-import com.chaosbuffalo.mkultra.core.ArmorClass;
-import com.chaosbuffalo.mkultra.core.PlayerAbility;
-import com.chaosbuffalo.mkultra.core.PlayerClass;
+import com.chaosbuffalo.mkultra.core.*;
 import com.chaosbuffalo.mkultra.core.abilities.*;
 import com.chaosbuffalo.mkultra.init.ModItems;
 import com.chaosbuffalo.mkultra.item.ClassIcon;
@@ -77,4 +75,8 @@ public class MoonKnight extends PlayerClass {
         return (ClassIcon) ModItems.moon_icon;
     }
 
+    @Override
+    public IClassClientData getClientData() {
+        return ClassClientData.MoonIcon.INSTANCE;
+    }
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/core/classes/NetherMage.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/classes/NetherMage.java
@@ -1,10 +1,8 @@
 package com.chaosbuffalo.mkultra.core.classes;
 
 import com.chaosbuffalo.mkultra.MKUltra;
-import com.chaosbuffalo.mkultra.core.PlayerAbility;
-import com.chaosbuffalo.mkultra.core.PlayerClass;
+import com.chaosbuffalo.mkultra.core.*;
 import com.chaosbuffalo.mkultra.core.abilities.*;
-import com.chaosbuffalo.mkultra.core.ArmorClass;
 import com.chaosbuffalo.mkultra.init.ModItems;
 import com.chaosbuffalo.mkultra.item.ClassIcon;
 import com.chaosbuffalo.mkultra.item.interfaces.IClassProvider;
@@ -71,5 +69,10 @@ public class NetherMage extends PlayerClass {
     @Override
     public IClassProvider getClassProvider() {
         return (ClassIcon) ModItems.sun_icon;
+    }
+
+    @Override
+    public IClassClientData getClientData() {
+        return ClassClientData.SunIcon.INSTANCE;
     }
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/core/classes/Ranger.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/classes/Ranger.java
@@ -2,6 +2,7 @@ package com.chaosbuffalo.mkultra.core.classes;
 
 import com.chaosbuffalo.mkultra.MKUltra;
 import com.chaosbuffalo.mkultra.core.ArmorClass;
+import com.chaosbuffalo.mkultra.core.IClassClientData;
 import com.chaosbuffalo.mkultra.core.PlayerAbility;
 import com.chaosbuffalo.mkultra.core.PlayerClass;
 import com.chaosbuffalo.mkultra.core.abilities.*;
@@ -10,6 +11,7 @@ import com.chaosbuffalo.mkultra.item.ClassIcon;
 import com.chaosbuffalo.mkultra.item.interfaces.IClassProvider;
 import com.chaosbuffalo.mkultra.tiles.TileEntityNPCSpawner;
 import net.minecraft.item.Item;
+import net.minecraft.util.ResourceLocation;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +20,8 @@ import java.util.List;
  * Created by Jacob on 6/23/2018.
  */
 public class Ranger extends PlayerClass {
+    public static ResourceLocation ID = new ResourceLocation(MKUltra.MODID, "class.ranger");
+    private static ClientData clientData = new ClientData();
 
     public static final List<PlayerAbility> abilities = new ArrayList<>(5);
     static {
@@ -29,7 +33,7 @@ public class Ranger extends PlayerClass {
     }
 
     public Ranger() {
-        super(MKUltra.MODID, "class.ranger");
+        super(ID);
     }
 
     @Override
@@ -75,5 +79,32 @@ public class Ranger extends PlayerClass {
     @Override
     public IClassProvider getClassProvider() {
         return new TileEntityNPCSpawner();
+    }
+
+    @Override
+    public IClassClientData getClientData() {
+        return clientData;
+    }
+
+    private static class ClientData implements IClassClientData {
+        @Override
+        public ResourceLocation getIconForProvider() {
+            return new ResourceLocation(MKUltra.MODID, "textures/class/icons/ranger.png");
+        }
+
+        @Override
+        public String getXpTableText() {
+            return "The Watchful Ranger taught you the basics, but you must exchange brouzouf to learn more.";
+        }
+
+        @Override
+        public ResourceLocation getXpTableBackground() {
+            return new ResourceLocation(MKUltra.MODID, "textures/gui/xp_table_background_ranger.png");
+        }
+
+        @Override
+        public int getXpTableTextColor() {
+            return 16707252;
+        }
     }
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/core/classes/Ranger.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/classes/Ranger.java
@@ -88,7 +88,7 @@ public class Ranger extends PlayerClass {
 
     private static class ClientData implements IClassClientData {
         @Override
-        public ResourceLocation getIconForProvider() {
+        public ResourceLocation getIcon() {
             return new ResourceLocation(MKUltra.MODID, "textures/class/icons/ranger.png");
         }
 

--- a/src/main/java/com/chaosbuffalo/mkultra/core/classes/Skald.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/classes/Skald.java
@@ -1,10 +1,8 @@
 package com.chaosbuffalo.mkultra.core.classes;
 
 import com.chaosbuffalo.mkultra.MKUltra;
-import com.chaosbuffalo.mkultra.core.PlayerAbility;
-import com.chaosbuffalo.mkultra.core.PlayerClass;
+import com.chaosbuffalo.mkultra.core.*;
 import com.chaosbuffalo.mkultra.core.abilities.*;
-import com.chaosbuffalo.mkultra.core.ArmorClass;
 import com.chaosbuffalo.mkultra.init.ModItems;
 import com.chaosbuffalo.mkultra.item.ClassIcon;
 import com.chaosbuffalo.mkultra.item.interfaces.IClassProvider;
@@ -71,5 +69,10 @@ public class Skald extends PlayerClass {
     @Override
     public IClassProvider getClassProvider() {
         return (ClassIcon) ModItems.sun_icon;
+    }
+
+    @Override
+    public IClassClientData getClientData() {
+        return ClassClientData.SunIcon.INSTANCE;
     }
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/core/classes/WaveKnight.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/classes/WaveKnight.java
@@ -1,9 +1,7 @@
 package com.chaosbuffalo.mkultra.core.classes;
 
 import com.chaosbuffalo.mkultra.MKUltra;
-import com.chaosbuffalo.mkultra.core.ArmorClass;
-import com.chaosbuffalo.mkultra.core.PlayerAbility;
-import com.chaosbuffalo.mkultra.core.PlayerClass;
+import com.chaosbuffalo.mkultra.core.*;
 import com.chaosbuffalo.mkultra.core.abilities.*;
 import com.chaosbuffalo.mkultra.init.ModItems;
 import com.chaosbuffalo.mkultra.item.ClassIcon;
@@ -77,5 +75,8 @@ public class WaveKnight extends PlayerClass {
         return (ClassIcon) ModItems.moon_icon;
     }
 
+    @Override
+    public IClassClientData getClientData() {
+        return ClassClientData.MoonIcon.INSTANCE;
+    }
 }
-

--- a/src/main/java/com/chaosbuffalo/mkultra/core/classes/WetWizard.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/classes/WetWizard.java
@@ -1,10 +1,8 @@
 package com.chaosbuffalo.mkultra.core.classes;
 
 import com.chaosbuffalo.mkultra.MKUltra;
-import com.chaosbuffalo.mkultra.core.PlayerAbility;
-import com.chaosbuffalo.mkultra.core.PlayerClass;
+import com.chaosbuffalo.mkultra.core.*;
 import com.chaosbuffalo.mkultra.core.abilities.*;
-import com.chaosbuffalo.mkultra.core.ArmorClass;
 import com.chaosbuffalo.mkultra.init.ModItems;
 import com.chaosbuffalo.mkultra.item.ClassIcon;
 import com.chaosbuffalo.mkultra.item.interfaces.IClassProvider;
@@ -71,5 +69,10 @@ public class WetWizard extends PlayerClass {
     @Override
     public IClassProvider getClassProvider() {
         return (ClassIcon) ModItems.sun_icon;
+    }
+
+    @Override
+    public IClassClientData getClientData() {
+        return ClassClientData.SunIcon.INSTANCE;
     }
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/init/ModItems.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/init/ModItems.java
@@ -3,9 +3,7 @@ package com.chaosbuffalo.mkultra.init;
 import com.chaosbuffalo.mkultra.MKUltra;
 import com.chaosbuffalo.mkultra.core.PlayerAttributes;
 import com.chaosbuffalo.mkultra.item.*;
-import net.minecraft.block.Block;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
-import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.*;
@@ -121,22 +119,16 @@ public final class ModItems {
 
         regInternal(sun_icon = new ClassIcon("sun_icon",
                 "The Sun God will bestow on you great powers. Choose your class: ", 8,
-                new ResourceLocation(MKUltra.MODID, "textures/class/icons/sun.png"),
-                "Give your Brouzoufs to Solarius. Receive his blessings.",
-                new ResourceLocation(MKUltra.MODID, "textures/gui/xp_table_background.png")
-                , 38600).setCreativeTab(MKUltra.MKULTRA_TAB), "sun_icon");
+                new ResourceLocation(MKUltra.MODID, "textures/class/icons/sun.png")
+        ).setCreativeTab(MKUltra.MKULTRA_TAB), "sun_icon");
         regInternal(moon_icon = new ClassIcon("moon_icon",
                 "The Mysterious Moon Goddess offers her arts to you. Choose your class: ", 1,
-                new ResourceLocation(MKUltra.MODID, "textures/class/icons/moon.png"),
-                "Thalassa, Goddess of the Moon, demands brouzouf in exchange for her powers.",
-                new ResourceLocation(MKUltra.MODID, "textures/gui/xp_table_background_moon.png")
-                , 4404838).setCreativeTab(MKUltra.MKULTRA_TAB), "moon_icon");
+                new ResourceLocation(MKUltra.MODID, "textures/class/icons/moon.png")
+        ).setCreativeTab(MKUltra.MKULTRA_TAB), "moon_icon");
         regInternal(desperate_icon = new ClassIcon("desperate_icon",
                 "The Enigmatic Wood Spirit offers her power to you. Choose your class: ",
-                1, new ResourceLocation(MKUltra.MODID, "textures/class/icons/desperate.png"),
-                "Ydira, Elusive Spirit of the Wood, will increase your powers in exchange for brouzouf.",
-                new ResourceLocation(MKUltra.MODID, "textures/gui/xp_table_background_desperate.png"),
-                32025).setCreativeTab(MKUltra.MKULTRA_TAB), "desperate_icon");
+                1, new ResourceLocation(MKUltra.MODID, "textures/class/icons/desperate.png")
+        ).setCreativeTab(MKUltra.MKULTRA_TAB), "desperate_icon");
         regInternal(forgetfulnessBread = new ForgetfulnessBread(8, 1.0f, false)
                 .setCreativeTab(MKUltra.MKULTRA_TAB), "forgetfulness_bread");
 

--- a/src/main/java/com/chaosbuffalo/mkultra/item/ClassIcon.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/item/ClassIcon.java
@@ -45,7 +45,7 @@ public class ClassIcon extends Item implements IClassProvider {
     }
 
     @Override
-    public ResourceLocation getIconForProvider() {
+    public ResourceLocation getIdentity() {
         return iconLoc;
     }
 

--- a/src/main/java/com/chaosbuffalo/mkultra/item/ClassIcon.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/item/ClassIcon.java
@@ -21,20 +21,13 @@ public class ClassIcon extends Item implements IClassProvider {
 
     private final String iconText;
     private final ResourceLocation iconLoc;
-    private final String xpTableText;
-    private final ResourceLocation xpTableBackground;
-    private final int xpTableTextColor;
 
-    public ClassIcon(String unlocalizedName, String iconText, int maxDamageIn, ResourceLocation iconLoc,
-                     String xpTableText, ResourceLocation xpTableBackground, int xpTableTextColor) {
+    public ClassIcon(String unlocalizedName, String iconText, int maxDamageIn, ResourceLocation iconLoc) {
         super();
         this.setTranslationKey(unlocalizedName);
         this.setCreativeTab(MKUltra.MKULTRA_TAB);
         this.iconText = iconText;
         this.iconLoc = iconLoc;
-        this.xpTableText = xpTableText;
-        this.xpTableBackground = xpTableBackground;
-        this.xpTableTextColor = xpTableTextColor;
         this.setMaxDamage(maxDamageIn);
         this.setMaxStackSize(1);
     }
@@ -52,11 +45,6 @@ public class ClassIcon extends Item implements IClassProvider {
     }
 
     @Override
-    public String getXpTableText() {
-        return xpTableText;
-    }
-
-    @Override
     public ResourceLocation getIconForProvider() {
         return iconLoc;
     }
@@ -64,16 +52,6 @@ public class ClassIcon extends Item implements IClassProvider {
     @Override
     public String getClassSelectionText() {
         return iconText;
-    }
-
-    @Override
-    public ResourceLocation getXpTableBackground() {
-        return xpTableBackground;
-    }
-
-    @Override
-    public int getXpTableTextColor() {
-        return xpTableTextColor;
     }
 
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/item/DiamondDust.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/item/DiamondDust.java
@@ -44,19 +44,4 @@ public class DiamondDust extends Item implements IClassProvider {
     public String getClassSelectionText() {
         return "Select your next class";
     }
-
-    @Override
-    public String getXpTableText() {
-        return "You shouldn't see this.";
-    }
-
-    @Override
-    public ResourceLocation getXpTableBackground() {
-        return new ResourceLocation(MKUltra.MODID, "textures/gui/xp_table_background_moon.png");
-    }
-
-    @Override
-    public int getXpTableTextColor() {
-        return 38600;
-    }
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/item/DiamondDust.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/item/DiamondDust.java
@@ -36,7 +36,7 @@ public class DiamondDust extends Item implements IClassProvider {
     }
 
     @Override
-    public ResourceLocation getIconForProvider() {
+    public ResourceLocation getIdentity() {
         return new ResourceLocation(MKUltra.MODID, "textures/items/sun_icon.png");
     }
 

--- a/src/main/java/com/chaosbuffalo/mkultra/item/interfaces/IClassProvider.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/item/interfaces/IClassProvider.java
@@ -1,9 +1,8 @@
 package com.chaosbuffalo.mkultra.item.interfaces;
 
-import com.chaosbuffalo.mkultra.core.IClassClientData;
 import net.minecraft.util.ResourceLocation;
 
-public interface IClassProvider extends IClassClientData {
+public interface IClassProvider {
     ResourceLocation getIconForProvider();
     String getClassSelectionText();
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/item/interfaces/IClassProvider.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/item/interfaces/IClassProvider.java
@@ -1,8 +1,18 @@
 package com.chaosbuffalo.mkultra.item.interfaces;
 
+import com.chaosbuffalo.mkultra.core.PlayerClass;
 import net.minecraft.util.ResourceLocation;
 
 public interface IClassProvider {
-    ResourceLocation getIconForProvider();
+    ResourceLocation getIdentity();
     String getClassSelectionText();
+
+    default boolean isSameAs(IClassProvider other) {
+        return getIdentity().compareTo(other.getIdentity()) == 0;
+    }
+
+    default boolean teachesClass(PlayerClass playerClass) {
+        // Temporary. Will be refactored when classes no longer declare their providers
+        return playerClass.getClassProvider().isSameAs(this);
+    }
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/item/interfaces/IClassProvider.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/item/interfaces/IClassProvider.java
@@ -1,11 +1,9 @@
 package com.chaosbuffalo.mkultra.item.interfaces;
 
+import com.chaosbuffalo.mkultra.core.IClassClientData;
 import net.minecraft.util.ResourceLocation;
 
-public interface IClassProvider {
+public interface IClassProvider extends IClassClientData {
     ResourceLocation getIconForProvider();
     String getClassSelectionText();
-    String getXpTableText();
-    ResourceLocation getXpTableBackground();
-    int getXpTableTextColor();
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/tiles/TileEntityNPCSpawner.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/tiles/TileEntityNPCSpawner.java
@@ -278,19 +278,4 @@ public class TileEntityNPCSpawner extends TileEntity implements ITickable, IClas
     public String getClassSelectionText() {
         return "The Watchful Ranger offers to teach you his knowledge. Choose your class: ";
     }
-
-    @Override
-    public String getXpTableText() {
-        return "The Watchful Ranger taught you the basics, but you must exchange brouzouf to learn more.";
-    }
-
-    @Override
-    public ResourceLocation getXpTableBackground() {
-        return new ResourceLocation(MKUltra.MODID, "textures/gui/xp_table_background_ranger.png");
-    }
-
-    @Override
-    public int getXpTableTextColor() {
-        return 16707252;
-    }
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/tiles/TileEntityNPCSpawner.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/tiles/TileEntityNPCSpawner.java
@@ -270,7 +270,7 @@ public class TileEntityNPCSpawner extends TileEntity implements ITickable, IClas
     }
 
     @Override
-    public ResourceLocation getIconForProvider() {
+    public ResourceLocation getIdentity() {
         return new ResourceLocation(MKUltra.MODID, "textures/class/icons/ranger.png");
     }
 


### PR DESCRIPTION
Introduce IClassClientData to hold class display metadata that is not dependent on how the player acquired the class. IClassProvider will eventually only be used to teach classes to players.