### PR TITLE
Prevent SpellTrigger callbacks from triggering more callbacks

### DIFF
--- a/src/main/java/com/chaosbuffalo/mkultra/MKConfig.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/MKConfig.java
@@ -12,7 +12,7 @@ import net.minecraft.item.ItemArmor;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.config.Config;
 import net.minecraftforge.common.config.Configuration;
-import net.minecraftforge.fml.relauncher.ReflectionHelper;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -263,10 +263,10 @@ public class MKConfig {
         }
     }
 
-    public static void registerArmorFromItemName(String name, ArmorClass armorClass){
+    public static void registerArmorFromItemName(String name, ArmorClass armorClass) {
         ResourceLocation itemName = new ResourceLocation(name);
         Item item = Item.REGISTRY.getObject(itemName);
-        if (item instanceof ItemArmor){
+        if (item instanceof ItemArmor) {
             Log.info("Registering Item: %s for Armor Class: %s", name,
                     armorClass.getLocation().toString());
             armorClass.registerItem((ItemArmor) item);
@@ -277,7 +277,7 @@ public class MKConfig {
     }
 
     private static String getArmorName(ItemArmor.ArmorMaterial mat) {
-        return ReflectionHelper.getPrivateValue(ItemArmor.ArmorMaterial.class, mat, "name", "field_179243_f", "f");
+        return ObfuscationReflectionHelper.getPrivateValue(ItemArmor.ArmorMaterial.class, mat, "field_179243_f"); // name
     }
 
     public static void registerArmors() {
@@ -317,6 +317,4 @@ public class MKConfig {
             e1.printStackTrace();
         }
     }
-
-
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/core/MKDamageSource.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/MKDamageSource.java
@@ -19,8 +19,6 @@ public class MKDamageSource extends EntityDamageSourceIndirect {
     private static String MOB_ABILITY_DAMAGE_TYPE = "mkUltraMobAbility";
     private static String MELEE_ABILITY_DMG_TYPE = "mkUltraMeleeAbility";
 
-    private boolean ignoreTriggerOnAttackEntity;
-
     private final ResourceLocation abilityId;
 
     public ResourceLocation getAbilityId() {
@@ -31,7 +29,6 @@ public class MKDamageSource extends EntityDamageSourceIndirect {
                           Entity source, @Nullable Entity indirectEntityIn) {
         super(damageTypeIn, source, indirectEntityIn);
         this.abilityId = abilityId;
-        this.ignoreTriggerOnAttackEntity = false;
     }
 
     public boolean isIndirectMagic() {
@@ -58,23 +55,6 @@ public class MKDamageSource extends EntityDamageSourceIndirect {
         return new MKDamageSource(abilityId, MOB_ABILITY_DAMAGE_TYPE, source, indirectEntityIn)
                 .setDamageBypassesArmor()
                 .setMagicDamage();
-    }
-
-    public static DamageSource causeIndirectMagicDamageIgnoreAttackTriggers(ResourceLocation abilityId, Entity source,
-                                                                            @Nullable Entity indirectEntityIn) {
-        return new MKDamageSource(abilityId, ABILITY_DMG_TYPE, source, indirectEntityIn)
-                .setIgnoreAttackTriggers()
-                .setDamageBypassesArmor()
-                .setMagicDamage();
-    }
-
-    public DamageSource setIgnoreAttackTriggers() {
-        this.ignoreTriggerOnAttackEntity = true;
-        return this;
-    }
-
-    public boolean ignoreAttackEntityTrigger() {
-        return ignoreTriggerOnAttackEntity;
     }
 
     public static DamageSource fromMeleeSkill(ResourceLocation abilityId, Entity source,

--- a/src/main/java/com/chaosbuffalo/mkultra/core/PlayerData.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/core/PlayerData.java
@@ -73,6 +73,7 @@ public class PlayerData implements IPlayerData {
     private EnumHandSide originalMainHand;
     private boolean isDualWielding;
     private int ticksSinceLastSwing;
+    private boolean inSpellTriggerCallback;
     private final static int DUAL_WIELD_TIMEOUT = 25;
 
 
@@ -1383,5 +1384,13 @@ public class PlayerData implements IPlayerData {
 
             sender.sendMessage(new TextComponentString(msg));
         }
+    }
+
+    public void setInSpellTriggerCallback(boolean enable) {
+        inSpellTriggerCallback = enable;
+    }
+
+    public boolean isInSpellTriggerCallback() {
+        return inSpellTriggerCallback;
     }
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/effects/spells/FlameBladeEffectPotion.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/effects/spells/FlameBladeEffectPotion.java
@@ -45,7 +45,7 @@ public class FlameBladeEffectPotion extends SpellPotionBase {
             damage = damage * 2.0f;
         }
 
-        target.attackEntityFrom(MKDamageSource.causeIndirectMagicDamageIgnoreAttackTriggers(
+        target.attackEntityFrom(MKDamageSource.causeIndirectMagicDamage(
                 new FlameBlade().getAbilityId(), applier, caster), damage);
     }
 }

--- a/src/main/java/com/chaosbuffalo/mkultra/effects/spells/UndertowPotion.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/effects/spells/UndertowPotion.java
@@ -45,7 +45,7 @@ public class UndertowPotion extends PassiveEffect {
         if (target instanceof EntityLivingBase) {
             EntityLivingBase livingEnt = (EntityLivingBase) target;
             if (livingEnt.isPotionActive(DrownPotion.INSTANCE)) {
-                livingEnt.attackEntityFrom(MKDamageSource.causeIndirectMagicDamageIgnoreAttackTriggers(
+                livingEnt.attackEntityFrom(MKDamageSource.causeIndirectMagicDamage(
                         new Undertow().getAbilityId(), livingEnt, player),
                         5.0f * effect.getAmplifier());
             }

--- a/src/main/java/com/chaosbuffalo/mkultra/event/CombatEventHandler.java
+++ b/src/main/java/com/chaosbuffalo/mkultra/event/CombatEventHandler.java
@@ -2,7 +2,6 @@ package com.chaosbuffalo.mkultra.event;
 
 import com.chaosbuffalo.mkultra.MKUltra;
 import com.chaosbuffalo.mkultra.core.IPlayerData;
-import com.chaosbuffalo.mkultra.core.MKDamageSource;
 import com.chaosbuffalo.mkultra.core.MKUPlayerData;
 import com.chaosbuffalo.mkultra.effects.SpellTriggers;
 import com.chaosbuffalo.mkultra.network.packets.PlayerLeftClickEmptyPacket;
@@ -67,12 +66,6 @@ public class CombatEventHandler {
 
         DamageSource dmgSource = event.getSource();
         Entity source = dmgSource.getTrueSource();
-        if (dmgSource instanceof MKDamageSource) {
-            MKDamageSource mkSource = (MKDamageSource) dmgSource;
-            if (mkSource.ignoreAttackEntityTrigger()) {
-                return;
-            }
-        }
         if (source instanceof EntityLivingBase) {
             SpellTriggers.ATTACK_ENTITY.onAttackEntity((EntityLivingBase) source, target);
         }


### PR DESCRIPTION
Removes the need for effect writers to know whether to call
MKDamageSource.causeIndirectMagicDamage or
MKDamageSource.causeIndirectMagicDamageIgnoreAttackTriggers